### PR TITLE
feat: 🎸 Support json field updates by removing restrictions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -359,12 +359,17 @@ exports.init = function (sequelize, optionsArg) {
       previousVersion = instance._previousDataValues;
       currentVersion = instance.dataValues;
     }
-
-    // HACK: strip all datavalues which are both capitalized and typeof === object. This is to:
-    // 1) Include fields which contain JSON objects to be included in the diff
-    // 2) Prevent circular calls by diffing nested models associated to the primary model
-    previousVersion = _.omitBy(previousVersion, (val, key) => key[0] === key[0].toUpperCase() && _.isObject(val));
-    currentVersion = _.omitBy(currentVersion, (val, key) => key[0] === key[0].toUpperCase() && _.isObject(val));
+    
+    const isSequelizeModel = (value) => {
+      if (_.isArray(value)) {
+        return value[0] instanceof sequelize.Model;
+      }
+      return value instanceof sequelize.Model
+    }
+    
+    // Prevents diffing associated models leading to circular calls
+    previousVersion = _.omitBy(previousVersion, (val, key) => isSequelizeModel(val));
+    currentVersion = _.omitBy(currentVersion, (val, key) => isSequelizeModel(val));
 
     // Disallow change of revision
     instance.set(options.revisionAttribute, instance._previousDataValues[options.revisionAttribute]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -361,6 +361,7 @@ exports.init = function (sequelize, optionsArg) {
     }
     
     const isSequelizeModel = (value) => {
+      // Models associated by `hasMany` will appear as arrays of Models, we need to strip those out too.
       if (_.isArray(value)) {
         return value[0] instanceof sequelize.Model;
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -345,10 +345,10 @@ exports.init = function (sequelize, optionsArg) {
       opt.transaction = instance.context.transaction;
     }
 
-    if (options.enableCompression) {
-      var previousVersion = {};
-      var currentVersion = {};
+    let previousVersion = {};
+    let currentVersion = {};
 
+    if (options.enableCompression) {
       _.forEach(opt.defaultFields, function (a) {
         if (!instance._previousDataValues[a].dataValues && !instance.dataValues[a].dataValues) {
           previousVersion[a] = instance._previousDataValues[a];
@@ -356,12 +356,15 @@ exports.init = function (sequelize, optionsArg) {
         }
       });
     } else {
-      var previousVersion = instance._previousDataValues;
-      var currentVersion = instance.dataValues;
+      previousVersion = instance._previousDataValues;
+      currentVersion = instance.dataValues;
     }
-    // Supported nested models.
-    previousVersion = _.omitBy(previousVersion, function (i) {return typeof i === 'object'});
-    currentVersion = _.omitBy(currentVersion, function (i) {return typeof i === 'object'});
+
+    // HACK: strip all datavalues which are both capitalized and typeof === object. This is to:
+    // 1) Include fields which contain JSON objects to be included in the diff
+    // 2) Prevent circular calls by diffing nested models associated to the primary model
+    previousVersion = _.omitBy(previousVersion, (val, key) => key[0] === key[0].toUpperCase() && _.isObject(val));
+    currentVersion = _.omitBy(currentVersion, (val, key) => key[0] === key[0].toUpperCase() && _.isObject(val));
 
     // Disallow change of revision
     instance.set(options.revisionAttribute, instance._previousDataValues[options.revisionAttribute]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -366,10 +366,10 @@ exports.init = function (sequelize, optionsArg) {
       }
       return value instanceof sequelize.Model
     }
-    
+
     // Prevents diffing associated models leading to circular calls
-    previousVersion = _.omitBy(previousVersion, (val, key) => isSequelizeModel(val));
-    currentVersion = _.omitBy(currentVersion, (val, key) => isSequelizeModel(val));
+    previousVersion = _.omitBy(previousVersion, val => isSequelizeModel(val));
+    currentVersion = _.omitBy(currentVersion, val => isSequelizeModel(val));
 
     // Disallow change of revision
     instance.set(options.revisionAttribute, instance._previousDataValues[options.revisionAttribute]);


### PR DESCRIPTION
Problem: at Goodway we frequently use JSONB fields in Postgres. `sequelize-paper-trail` strips out any field which has `typeof ${key} === 'object'` in order to prevent circular calls when diffing a `queryResult` that is associated to other Models. A side effect of this is that no JSONB fields will ever have their changes tracked.

This fix is to check explicitly if the value being checked is an instanceof sequelize.Model, rather than stripping out all objects.

----

In working on this I initially tried to set up the most recent version of https://github.com/nielsgl/sequelize-paper-trail with `api-looking-glass`. Not only had the issue of not tracking JSON not been addressed, but it seems like the project has been abandoned at a more or less broken state, where *no* updates were able to be tracked, userIds associated with changes are not tracked, and transaction ids are not tracking.

At an upcoming microservices guild I'd like to have a roundtable on the importance of being able to preserve audit logs of changes to our databases, what we would like out of an audit log, and align on a path forward.